### PR TITLE
feat(DQL): Add keyword every to DQL

### DIFF
--- a/gql/parser.go
+++ b/gql/parser.go
@@ -2612,7 +2612,7 @@ func parseLanguageList(it *lex.ItemIterator) ([]string, error) {
 
 func validKeyAtRoot(k string) bool {
 	switch k {
-	case "func", "orderasc", "orderdesc", "first", "offset", "after", "random":
+	case "func", "orderasc", "orderdesc", "first", "offset", "after", "every", "random":
 		return true
 	case "from", "to", "numpaths", "minweight", "maxweight":
 		// Specific to shortest path
@@ -2626,7 +2626,7 @@ func validKeyAtRoot(k string) bool {
 // Check for validity of key at non-root nodes.
 func validKey(k string) bool {
 	switch k {
-	case "orderasc", "orderdesc", "first", "offset", "after", "random":
+	case "orderasc", "orderdesc", "first", "offset", "after", "every", "random":
 		return true
 	}
 	return false

--- a/query/query.go
+++ b/query/query.go
@@ -2459,28 +2459,20 @@ func ProcessGraph(ctx context.Context, sg, parent *SubGraph, rch chan error) {
 }
 
 // applies "every" to lists inside uidMatrix
-// the first node is selected from the concatenation of all uid lists, then every sg.Params.Every node
+// the first node is selected from each of the uid lists, then every sg.Params.Every node
 // nodes are selected after applying first, offset and after
 func (sg *SubGraph) applyEvery(ctx context.Context) error {
 	sg.updateUidMatrix()
 
-    start := 0
     every := sg.Params.Every
 	for i := 0; i < len(sg.uidMatrix); i++ {
 		uidList := codec.GetUids(sg.uidMatrix[i])
 
-		if start >= len(uidList) {
-		    start -= len(uidList)
-			continue
-		}
-
 		r := sroar.NewBitmap()
-        for j := start; j < len(uidList); j += every {
+        for j := 0; j < len(uidList); j += every {
 			r.Set(uidList[j])
         }
 		sg.uidMatrix[i].Bitmap = r.ToBuffer()
-
-        start = every - (len(uidList) - start) % every - 1
 	}
 
 	sg.DestMap = codec.Merge(sg.uidMatrix)

--- a/query/query4_test.go
+++ b/query/query4_test.go
@@ -760,7 +760,7 @@ func TestHasOrderAscOffset(t *testing.T) {
 
 func TestHasFirst(t *testing.T) {
 	query := `{
-		q(func:has(name),first:5) {
+		q(func:has(name), first:5) {
 			 name
 		 }
 	 }`
@@ -877,7 +877,7 @@ func TestRegExpVariableReplacement(t *testing.T) {
 
 func TestHasFirstOffset(t *testing.T) {
 	query := `{
-		q(func:has(name),first:5, offset: 5) {
+		q(func:has(name), first:5, offset: 5) {
 			 name
 		 }
 	 }`
@@ -943,6 +943,7 @@ func TestHasFilterOrderOffset(t *testing.T) {
 		  }
 	}`, js)
 }
+
 func TestCascadeSubQuery1(t *testing.T) {
 	query := `
 	{
@@ -975,6 +976,99 @@ func TestCascadeSubQuery1(t *testing.T) {
 				}
 			]
 		}
+	}`, js)
+}
+
+func TestHasEvery(t *testing.T) {
+	query := `{
+		q(func:has(name), every:10) {
+			 name
+		 }
+	 }`
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{
+		"data": {
+			"q": [
+			  {
+				"name": "Michonne"
+			  },
+			  {
+				"name": "Daryl Dixon"
+			  },
+			  {
+				"name": "E"
+			  },
+			  {
+				"name": "Bob"
+			  },
+			  {
+				"name": "School A"
+			  },
+			  {
+				"name": "Alice"
+			  }
+			]
+		  }
+	}`, js)
+}
+
+func TestHasFirstEvery(t *testing.T) {
+	query := `{
+		q(func:has(name), first: 10, every:2) {
+			 name
+		 }
+	 }`
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{
+		"data": {
+			"q": [
+			  {
+				"name": "Michonne"
+			  },
+			  {
+				"name": "Margaret"
+			  },
+			  {
+				"name": "Garfield"
+			  },
+			  {
+				"name": "Nemo"
+			  },
+			  {
+				"name": "Rick Grimes"
+			  }
+			]
+		  }
+	}`, js)
+}
+
+func TestHasFirstOffsetEvery(t *testing.T) {
+	query := `{
+		q(func:has(name), first: 10, offset:1, every:2) {
+			 name
+		 }
+	 }`
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{
+		"data": {
+			"q": [
+			  {
+				"name": "King Lear"
+			  },
+			  {
+				"name": "Leonard"
+			  },
+			  {
+				"name": "Bear"
+			  },
+			  {
+				"name": "name"
+			  },
+			  {
+				"name": "Glenn Rhee"
+			  }
+			]
+		  }
 	}`, js)
 }
 


### PR DESCRIPTION
Adds thekeyword `every` key to DQL. This is similar to 7693, but this picks equi-distant nodes deterministically. It provides a sample of the result / page, that is proportional in size. This can be combined with `first`, `offset`, and `after`.